### PR TITLE
Add ability to customise specified sats amount in QR code

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import "bootstrap/dist/css/bootstrap.min.css"
 import Home from "./components/home"
-import ReceiveNoAmount from "./components/receiveNoAmount"
-import ReceiveAmount from "./components/receiveAmount"
+import Receive from "./components/receive"
 import PrintQR from "./components/printQR"
 import DownloadApp from "./components/downloadApp"
 import { useRoutes } from "hookrouter"
@@ -13,11 +12,9 @@ const routes = {
   "/:username/print": ({ username }: { username: string }) => (
     <PrintQR username={username} />
   ),
-  "/:username": ({ username }: { username: string }) => (
-    <ReceiveNoAmount username={username} />
-  ),
+  "/:username": ({ username }: { username: string }) => <Receive username={username} />,
   "/:username/:amount": ({ username, amount }: { username: string; amount: number }) => (
-    <ReceiveAmount username={username} amount={amount} />
+    <Receive username={username} amount={amount} />
   ),
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import "bootstrap/dist/css/bootstrap.min.css"
 import Home from "./components/home"
-import Receive from "./components/receive"
+import ReceiveNoAmount from "./components/receiveNoAmount"
+import ReceiveAmount from "./components/receiveAmount"
 import PrintQR from "./components/printQR"
 import DownloadApp from "./components/downloadApp"
 import { useRoutes } from "hookrouter"
@@ -12,9 +13,11 @@ const routes = {
   "/:username/print": ({ username }: { username: string }) => (
     <PrintQR username={username} />
   ),
-  "/:username": ({ username }: { username: string }) => <Receive username={username} />,
+  "/:username": ({ username }: { username: string }) => (
+    <ReceiveNoAmount username={username} />
+  ),
   "/:username/:amount": ({ username, amount }: { username: string; amount: number }) => (
-    <Receive username={username} amount={amount} />
+    <ReceiveAmount username={username} amount={amount} />
   ),
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,9 @@ const routes = {
     <PrintQR username={username} />
   ),
   "/:username": ({ username }: { username: string }) => <Receive username={username} />,
+  "/:username/:amount": ({ username, amount }: { username: string; amount: number }) => (
+    <Receive username={username} amount={amount} />
+  ),
 }
 
 function App() {

--- a/src/components/receive.tsx
+++ b/src/components/receive.tsx
@@ -1,0 +1,82 @@
+import Row from "react-bootstrap/Row"
+import Col from "react-bootstrap/Col"
+import Card from "react-bootstrap/Card"
+import Container from "react-bootstrap/Container"
+import Image from "react-bootstrap/Image"
+
+import { getOS, appStoreLink, playStoreLink } from "./downloadApp"
+import ReceiveAmount from "./receiveAmount"
+import ReceiveNoAmount from "./receiveNoAmount"
+
+export default function Receive({
+  username,
+  amount,
+}: {
+  username: string
+  amount?: number
+}) {
+  const os = getOS()
+
+  return (
+    <Container fluid>
+      {os === undefined && <br />}
+      <Row className="justify-content-md-center">
+        <Col md="auto" style={{ padding: 0 }}>
+          <Card className="text-center">
+            {amount ? (
+              <ReceiveAmount username={username} amount={amount} />
+            ) : (
+              <ReceiveNoAmount username={username} />
+            )}
+
+            <Card.Body>
+              {os === "android" && (
+                <a href={playStoreLink}>
+                  <Image
+                    src={process.env.PUBLIC_URL + "/google-play-badge.png"}
+                    height="40px"
+                    rounded
+                  />
+                </a>
+              )}
+              {os === "ios" && (
+                <a href={playStoreLink}>
+                  <Image
+                    src={process.env.PUBLIC_URL + "/apple-app-store.png"}
+                    height="40px"
+                    rounded
+                  />
+                </a>
+              )}
+              {os === undefined && (
+                <div>
+                  <a href={appStoreLink}>
+                    <Image
+                      src={process.env.PUBLIC_URL + "/apple-app-store.png"}
+                      height="45px"
+                      rounded
+                    />
+                  </a>
+                  &nbsp;
+                  <a href={playStoreLink}>
+                    <Image
+                      src={process.env.PUBLIC_URL + "/google-play-badge.png"}
+                      height="45px"
+                      rounded
+                    />
+                  </a>
+                </div>
+              )}
+            </Card.Body>
+            <Card.Footer className="text-muted">
+              Powered by <Card.Link href="https://galoy.io">Galoy </Card.Link>
+              <br />
+              <Card.Link href={window.location.origin}>Open a channel with us</Card.Link>
+            </Card.Footer>
+          </Card>
+        </Col>
+      </Row>
+      <br />
+    </Container>
+  )
+}

--- a/src/components/receiveAmount.tsx
+++ b/src/components/receiveAmount.tsx
@@ -1,12 +1,7 @@
 import { useEffect } from "react"
-import Row from "react-bootstrap/Row"
-import Col from "react-bootstrap/Col"
 import Card from "react-bootstrap/Card"
-import Container from "react-bootstrap/Container"
-import Image from "react-bootstrap/Image"
 import { gql, useMutation } from "@apollo/client"
 
-import { getOS, appStoreLink, playStoreLink } from "./downloadApp"
 import Invoice from "./invoice"
 
 type OperationError = {
@@ -81,78 +76,23 @@ export default function ReceiveAmount({
     invoice = invoiceData.invoice
   }
 
-  const os = getOS()
-
   return (
-    <Container fluid>
-      {os === undefined && <br />}
-      <Row className="justify-content-md-center">
-        <Col md="auto" style={{ padding: 0 }}>
-          <Card className="text-center">
-            <Card.Header>
-              Pay {username} {amount} Sats
-            </Card.Header>
+    <>
+      <Card.Header>
+        Pay {username} {amount} Sats
+      </Card.Header>
 
-            {errorMessage && <div className="error">{uiErrorMessage(errorMessage)}</div>}
+      {errorMessage && <div className="error">{uiErrorMessage(errorMessage)}</div>}
 
-            {loading && !error && (
-              <div>
-                {" "}
-                <br />
-                Loading...
-              </div>
-            )}
+      {loading && !error && (
+        <div>
+          {" "}
+          <br />
+          Loading...
+        </div>
+      )}
 
-            {invoice && <Invoice paymentRequest={invoice.paymentRequest} />}
-
-            <Card.Body>
-              {os === "android" && (
-                <a href={playStoreLink}>
-                  <Image
-                    src={process.env.PUBLIC_URL + "/google-play-badge.png"}
-                    height="40px"
-                    rounded
-                  />
-                </a>
-              )}
-              {os === "ios" && (
-                <a href={playStoreLink}>
-                  <Image
-                    src={process.env.PUBLIC_URL + "/apple-app-store.png"}
-                    height="40px"
-                    rounded
-                  />
-                </a>
-              )}
-              {os === undefined && (
-                <div>
-                  <a href={appStoreLink}>
-                    <Image
-                      src={process.env.PUBLIC_URL + "/apple-app-store.png"}
-                      height="45px"
-                      rounded
-                    />
-                  </a>
-                  &nbsp;
-                  <a href={playStoreLink}>
-                    <Image
-                      src={process.env.PUBLIC_URL + "/google-play-badge.png"}
-                      height="45px"
-                      rounded
-                    />
-                  </a>
-                </div>
-              )}
-            </Card.Body>
-            <Card.Footer className="text-muted">
-              Powered by <Card.Link href="https://galoy.io">Galoy </Card.Link>
-              <br />
-              <Card.Link href={window.location.origin}>Open a channel with us</Card.Link>
-            </Card.Footer>
-          </Card>
-        </Col>
-      </Row>
-      <br />
-    </Container>
+      {invoice && <Invoice paymentRequest={invoice.paymentRequest} />}
+    </>
   )
 }

--- a/src/components/receiveAmount.tsx
+++ b/src/components/receiveAmount.tsx
@@ -17,21 +17,6 @@ type LnInvoiceObject = {
   paymentRequest: string
 }
 
-const LN_NOAMOUNT_INVOICE_CREATE_ON_BEHALF_OF_RECIPIENT = gql`
-  mutation lnNoAmountInvoiceCreateOnBehalfOfRecipient($walletName: WalletName!) {
-    mutationData: lnNoAmountInvoiceCreateOnBehalfOfRecipient(
-      input: { recipient: $walletName }
-    ) {
-      errors {
-        message
-      }
-      invoice {
-        paymentRequest
-      }
-    }
-  }
-`
-
 const LN_INVOICE_CREATE_ON_BEHALF_OF_RECIPIENT = gql`
   mutation lnInvoiceCreateOnBehalfOfRecipient(
     $walletName: WalletName!
@@ -60,35 +45,24 @@ function uiErrorMessage(errorMessage: string) {
   }
 }
 
-export default function Receive({
+export default function ReceiveAmount({
   username,
   amount,
 }: {
   username: string
-  amount?: number
+  amount: number
 }) {
-  let createInvoiceType
-  if (amount === undefined)
-    createInvoiceType = LN_NOAMOUNT_INVOICE_CREATE_ON_BEHALF_OF_RECIPIENT
-  else createInvoiceType = LN_INVOICE_CREATE_ON_BEHALF_OF_RECIPIENT
-
   const [createInvoice, { loading, error, data }] = useMutation<{
     mutationData: {
       errors: OperationError[]
       invoice?: LnInvoiceObject
     }
-  }>(createInvoiceType)
+  }>(LN_INVOICE_CREATE_ON_BEHALF_OF_RECIPIENT)
 
   useEffect(() => {
-    if (amount === undefined) {
-      createInvoice({
-        variables: { walletName: username },
-      })
-    } else {
-      createInvoice({
-        variables: { walletName: username, amount: amount },
-      })
-    }
+    createInvoice({
+      variables: { walletName: username, amount: amount },
+    })
   }, [createInvoice, username, amount])
 
   if (error) {
@@ -115,13 +89,9 @@ export default function Receive({
       <Row className="justify-content-md-center">
         <Col md="auto" style={{ padding: 0 }}>
           <Card className="text-center">
-            {amount ? (
-              <Card.Header>
-                Pay {username} {amount} Sats
-              </Card.Header>
-            ) : (
-              <Card.Header>Pay {username}</Card.Header>
-            )}
+            <Card.Header>
+              Pay {username} {amount} Sats
+            </Card.Header>
 
             {errorMessage && <div className="error">{uiErrorMessage(errorMessage)}</div>}
 

--- a/src/components/receiveNoAmount.tsx
+++ b/src/components/receiveNoAmount.tsx
@@ -1,0 +1,147 @@
+import { useEffect } from "react"
+import Row from "react-bootstrap/Row"
+import Col from "react-bootstrap/Col"
+import Card from "react-bootstrap/Card"
+import Container from "react-bootstrap/Container"
+import Image from "react-bootstrap/Image"
+import { gql, useMutation } from "@apollo/client"
+
+import { getOS, appStoreLink, playStoreLink } from "./downloadApp"
+import Invoice from "./invoice"
+
+type OperationError = {
+  message: string
+}
+
+type LnInvoiceObject = {
+  paymentRequest: string
+}
+
+const LN_NOAMOUNT_INVOICE_CREATE_ON_BEHALF_OF_RECIPIENT = gql`
+  mutation lnNoAmountInvoiceCreateOnBehalfOfRecipient($walletName: WalletName!) {
+    mutationData: lnNoAmountInvoiceCreateOnBehalfOfRecipient(
+      input: { recipient: $walletName }
+    ) {
+      errors {
+        message
+      }
+      invoice {
+        paymentRequest
+      }
+    }
+  }
+`
+
+function uiErrorMessage(errorMessage: string) {
+  switch (errorMessage) {
+    case "CouldNotFindError":
+      return "User not found"
+    default:
+      console.error(errorMessage)
+      return "Something went wrong"
+  }
+}
+
+export default function ReceiveNoAmount({ username }: { username: string }) {
+  const [createInvoice, { loading, error, data }] = useMutation<{
+    mutationData: {
+      errors: OperationError[]
+      invoice?: LnInvoiceObject
+    }
+  }>(LN_NOAMOUNT_INVOICE_CREATE_ON_BEHALF_OF_RECIPIENT)
+
+  useEffect(() => {
+    createInvoice({
+      variables: { walletName: username },
+    })
+  }, [createInvoice, username])
+
+  if (error) {
+    console.error(error)
+  }
+
+  let errorMessage, invoice
+
+  if (data) {
+    const invoiceData = data.mutationData
+
+    if (invoiceData.errors?.length > 0) {
+      errorMessage = invoiceData.errors[0].message
+    }
+
+    invoice = invoiceData.invoice
+  }
+
+  const os = getOS()
+
+  return (
+    <Container fluid>
+      {os === undefined && <br />}
+      <Row className="justify-content-md-center">
+        <Col md="auto" style={{ padding: 0 }}>
+          <Card className="text-center">
+            <Card.Header>Pay {username}</Card.Header>
+
+            {errorMessage && <div className="error">{uiErrorMessage(errorMessage)}</div>}
+
+            {loading && !error && (
+              <div>
+                {" "}
+                <br />
+                Loading...
+              </div>
+            )}
+
+            {invoice && <Invoice paymentRequest={invoice.paymentRequest} />}
+
+            <Card.Body>
+              {os === "android" && (
+                <a href={playStoreLink}>
+                  <Image
+                    src={process.env.PUBLIC_URL + "/google-play-badge.png"}
+                    height="40px"
+                    rounded
+                  />
+                </a>
+              )}
+              {os === "ios" && (
+                <a href={playStoreLink}>
+                  <Image
+                    src={process.env.PUBLIC_URL + "/apple-app-store.png"}
+                    height="40px"
+                    rounded
+                  />
+                </a>
+              )}
+              {os === undefined && (
+                <div>
+                  <a href={appStoreLink}>
+                    <Image
+                      src={process.env.PUBLIC_URL + "/apple-app-store.png"}
+                      height="45px"
+                      rounded
+                    />
+                  </a>
+                  &nbsp;
+                  <a href={playStoreLink}>
+                    <Image
+                      src={process.env.PUBLIC_URL + "/google-play-badge.png"}
+                      height="45px"
+                      rounded
+                    />
+                  </a>
+                </div>
+              )}
+            </Card.Body>
+            <Card.Footer className="text-muted">
+              Powered by <Card.Link href="https://galoy.io">Galoy </Card.Link>
+              <br />
+              <Card.Link href={window.location.origin}>Open a channel with us</Card.Link>
+            </Card.Footer>
+          </Card>
+        </Col>
+      </Row>
+      <br />
+    </Container>
+  )
+}

--- a/src/components/receiveNoAmount.tsx
+++ b/src/components/receiveNoAmount.tsx
@@ -1,12 +1,7 @@
 import { useEffect } from "react"
-import Row from "react-bootstrap/Row"
-import Col from "react-bootstrap/Col"
 import Card from "react-bootstrap/Card"
-import Container from "react-bootstrap/Container"
-import Image from "react-bootstrap/Image"
 import { gql, useMutation } from "@apollo/client"
 
-import { getOS, appStoreLink, playStoreLink } from "./downloadApp"
 import Invoice from "./invoice"
 
 type OperationError = {
@@ -72,76 +67,21 @@ export default function ReceiveNoAmount({ username }: { username: string }) {
     invoice = invoiceData.invoice
   }
 
-  const os = getOS()
-
   return (
-    <Container fluid>
-      {os === undefined && <br />}
-      <Row className="justify-content-md-center">
-        <Col md="auto" style={{ padding: 0 }}>
-          <Card className="text-center">
-            <Card.Header>Pay {username}</Card.Header>
+    <>
+      <Card.Header>Pay {username}</Card.Header>
 
-            {errorMessage && <div className="error">{uiErrorMessage(errorMessage)}</div>}
+      {errorMessage && <div className="error">{uiErrorMessage(errorMessage)}</div>}
 
-            {loading && !error && (
-              <div>
-                {" "}
-                <br />
-                Loading...
-              </div>
-            )}
+      {loading && !error && (
+        <div>
+          {" "}
+          <br />
+          Loading...
+        </div>
+      )}
 
-            {invoice && <Invoice paymentRequest={invoice.paymentRequest} />}
-
-            <Card.Body>
-              {os === "android" && (
-                <a href={playStoreLink}>
-                  <Image
-                    src={process.env.PUBLIC_URL + "/google-play-badge.png"}
-                    height="40px"
-                    rounded
-                  />
-                </a>
-              )}
-              {os === "ios" && (
-                <a href={playStoreLink}>
-                  <Image
-                    src={process.env.PUBLIC_URL + "/apple-app-store.png"}
-                    height="40px"
-                    rounded
-                  />
-                </a>
-              )}
-              {os === undefined && (
-                <div>
-                  <a href={appStoreLink}>
-                    <Image
-                      src={process.env.PUBLIC_URL + "/apple-app-store.png"}
-                      height="45px"
-                      rounded
-                    />
-                  </a>
-                  &nbsp;
-                  <a href={playStoreLink}>
-                    <Image
-                      src={process.env.PUBLIC_URL + "/google-play-badge.png"}
-                      height="45px"
-                      rounded
-                    />
-                  </a>
-                </div>
-              )}
-            </Card.Body>
-            <Card.Footer className="text-muted">
-              Powered by <Card.Link href="https://galoy.io">Galoy </Card.Link>
-              <br />
-              <Card.Link href={window.location.origin}>Open a channel with us</Card.Link>
-            </Card.Footer>
-          </Card>
-        </Col>
-      </Row>
-      <br />
-    </Container>
+      {invoice && <Invoice paymentRequest={invoice.paymentRequest} />}
+    </>
   )
 }


### PR DESCRIPTION
Implements https://github.com/GaloyMoney/lnpage/issues/40

**Changes**
If the user navigates to the route: `/:username/:amountInSats` the UI will generate a QR code with the number automatically filling the value of the transaction in the lightning wallet.

<img width="400" alt="Screenshot 2021-09-26 at 8 43 10 pm" src="https://user-images.githubusercontent.com/864576/134821891-5d0748ac-69d0-4437-b4cc-4f931ee1bd8f.png">
<img width="399" alt="Screenshot 2021-09-26 at 8 43 00 pm" src="https://user-images.githubusercontent.com/864576/134821893-7e16a6d6-52c6-4533-ad6d-0a52c56f63e7.png">


